### PR TITLE
change menu chevron directions: down when not expanded, up when expanded

### DIFF
--- a/src/framework/theme/components/menu/menu-item.component.html
+++ b/src/framework/theme/components/menu/menu-item.component.html
@@ -41,8 +41,8 @@
    href="#">
   <i class="menu-icon {{ menuItem.icon }}" *ngIf="menuItem.icon"></i>
   <span class="menu-title">{{ menuItem.title }}</span>
-  <i class="ion chevron" [class.ion-chevron-left]="!menuItem.expanded"
-     [class.ion-chevron-down]="menuItem.expanded"></i>
+  <i class="ion chevron" [class.ion-chevron-down]="!menuItem.expanded"
+     [class.ion-chevron-up]="menuItem.expanded"></i>
 </a>
 <ul *ngIf="menuItem.children"
     [class.collapsed]="!(menuItem.children && menuItem.expanded)"


### PR DESCRIPTION
Currently, the chevrons for menu items with submenus have weird behavior: when the submenu is collapsed, chevrons point to the left, and when the submenu is expanded the chevrons point down.

With this change, the chevron directions reflect expected behavior for submenus: down when collapsed and up when expanded. This shows the user which direction they can expect the menu to move when these items are clicked.

Gif demonstation:
![2018-07-20 11 39 16](https://user-images.githubusercontent.com/12586676/43019514-1f2e76f4-8c12-11e8-8deb-c5b3733d4109.gif)
